### PR TITLE
feat: add professional organization profile README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,12 +1,67 @@
-## Hi there 👋
+# labrats.work
 
-<!--
+> **Modern cloud-native infrastructure and applications** — Powered by Kubernetes, GitOps, and AI automation
 
-**Here are some ideas to get you started:**
+---
 
-🙋‍♀️ A short introduction - what is your organization all about?
-🌈 Contribution guidelines - how can the community get involved?
-👩‍💻 Useful resources - where can the community find your docs? Is there anything else the community should know?
-🍿 Fun facts - what does your team eat for breakfast?
-🧙 Remember, you can do mighty things with the power of [Markdown](https://docs.github.com/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)
--->
+## 🏗️ Infrastructure
+
+**Cloud-Native Stack**
+- 🚀 **Kubernetes** on Hetzner Cloud — Production-grade cluster with Longhorn storage
+- 🔄 **GitOps with FluxCD** — Declarative infrastructure management
+- 🏗️ **Infrastructure as Code** — Terraform + Ansible for reproducible deployments
+- 🔐 **Security-First** — SOPS encryption, non-root containers, read-only filesystems
+
+## 🤖 AI-Powered Development
+
+**GitHub AI Agents** — Organization-wide automation
+- 🔧 Automated issue implementation and PR reviews
+- 📊 CI/CD diagnostics and failure analysis
+- 🔄 Continuous compliance checking
+- 🚀 Self-healing workflows
+
+## 🛠️ Technology Stack
+
+| Layer | Technologies |
+|-------|-------------|
+| **Frontend** | Next.js 15+, React 19, TypeScript, Tailwind CSS v4 |
+| **Backend** | Node.js, Python (Flask), Go, .NET Core |
+| **Database** | MongoDB, Redis, SQLite |
+| **Infrastructure** | Kubernetes, FluxCD, Terraform, Ansible |
+| **CI/CD** | GitHub Actions, ARC Runners, Kaniko |
+| **Monitoring** | Prometheus, Grafana, Goss |
+
+## 📦 Featured Projects
+
+### Infrastructure
+- **labrats.work.hetzner.cluster** — Kubernetes infrastructure on Hetzner Cloud
+- **labrats-compliance** — Automated compliance checking and enforcement
+- **apps.dev-containers** — Cloud development environments
+
+### Applications
+- **apps.github-ai-agents** — Org-wide GitHub AI automation service
+- **apps.my-diet** — Recipe management with nutrition tracking (MongoDB, Next.js)
+- **apps.my-cams** — Media server with FFmpeg transcoding (Go, Next.js)
+- **apps.navidrome** — Music streaming server deployment
+
+### Automation
+- **actions.common** — Reusable GitHub Actions workflows
+- **github-runners** — Self-hosted ARC runners configuration
+
+## 🌟 Highlights
+
+- ✅ **100% GitOps** — All infrastructure changes via Git
+- 🤖 **AI-First Development** — Claude AI agents handle routine tasks
+- 🔒 **Security Hardened** — SOPS secrets, branch protection, automated scanning
+- 📊 **Observable** — Prometheus metrics, structured logging, health checks
+- 🚀 **Fast Iteration** — PR previews, auto-deployments, instant rollbacks
+
+## 📍 Location
+
+Warsaw, Poland 🇵🇱
+
+---
+
+<div align="center">
+  <sub>Built with ❤️ using modern DevOps practices</sub>
+</div>


### PR DESCRIPTION
## Summary

Replaces the default GitHub organization profile template with a comprehensive, professional README showcasing labrats-work's infrastructure and capabilities.

## What's New

### 🎯 Professional Branding
- Clear tagline: "Modern cloud-native infrastructure and applications"
- Organized sections with icons and visual hierarchy
- Professional formatting with tables and badges

### 📋 Content Sections
1. **Infrastructure** — Kubernetes, GitOps, IaC overview
2. **AI-Powered Development** — GitHub AI Agents capabilities
3. **Technology Stack** — Comprehensive tech table
4. **Featured Projects** — Organized by category (Infrastructure, Applications, Automation)
5. **Highlights** — Key differentiators (GitOps, AI-First, Security)

### 🎨 Design
- Clean, scannable layout
- Emoji icons for visual interest
- Tables for structured information
- Professional footer with location

## Preview

The profile will be visible at: https://github.com/labrats-work

## Impact

- ✅ Professional first impression for visitors
- ✅ Clear communication of org capabilities
- ✅ Easy navigation to key projects
- ✅ Showcases technical sophistication

🤖 Generated with [Claude Code](https://claude.com/claude-code)